### PR TITLE
fix: path include pattern char cause relative path issue

### DIFF
--- a/lua/cybu/utils.lua
+++ b/lua/cybu/utils.lua
@@ -80,7 +80,9 @@ function utils.get_relative_path(path, cwd_path)
     cwd_path = cwd_path:gsub("\\", "/")
     path = path:gsub("\\", "/")
   end
-  return string.gsub(path, cwd_path, "")
+
+  local Path = require("plenary.path")
+  return Path:new(path):make_relative(cwd_path)
 end
 
 function utils.is_filter_active()


### PR DESCRIPTION
Use `plenary.path`'s `make_relative` instead of `string.gsub`, because which will cause issue when path include pattern char. e.g.: 
`:lua =string.gsub("/foo-bar/src/index", "/foo-bar", "")`